### PR TITLE
Improved frequency normalization algorithm

### DIFF
--- a/src/lzfse_encode_base.c
+++ b/src/lzfse_encode_base.c
@@ -172,10 +172,10 @@ static int lzfse_encode_matches(lzfse_encoder_state *s) {
   if (s->n_literals == 0 && s->n_matches == 0)
     return LZFSE_STATUS_OK; // nothing to store, OK
 
-  fse_occurrence_entry l_occ[LZFSE_ENCODE_L_SYMBOLS];
-  fse_occurrence_entry m_occ[LZFSE_ENCODE_M_SYMBOLS];
-  fse_occurrence_entry d_occ[LZFSE_ENCODE_D_SYMBOLS];
-  fse_occurrence_entry literal_occ[LZFSE_ENCODE_LITERAL_SYMBOLS];
+  uint32_t l_occ[LZFSE_ENCODE_L_SYMBOLS];
+  uint32_t m_occ[LZFSE_ENCODE_M_SYMBOLS];
+  uint32_t d_occ[LZFSE_ENCODE_D_SYMBOLS];
+  uint32_t literal_occ[LZFSE_ENCODE_LITERAL_SYMBOLS];
   fse_encoder_entry l_encoder[LZFSE_ENCODE_L_SYMBOLS];
   fse_encoder_entry m_encoder[LZFSE_ENCODE_M_SYMBOLS];
   fse_encoder_entry d_encoder[LZFSE_ENCODE_D_SYMBOLS];
@@ -206,22 +206,10 @@ static int lzfse_encode_matches(lzfse_encoder_state *s) {
   }
 
   // Clear occurrence tables
-  for (int i = 0; i < LZFSE_ENCODE_L_SYMBOLS; i++) {
-    l_occ[i].symbol = i;
-    l_occ[i].count = 0;
-  }
-  for (int i = 0; i < LZFSE_ENCODE_M_SYMBOLS; i++) {
-    m_occ[i].symbol = i;
-    m_occ[i].count = 0;
-  }
-  for (int i = 0; i < LZFSE_ENCODE_D_SYMBOLS; i++) {
-    d_occ[i].symbol = i;
-    d_occ[i].count = 0;
-  }
-  for (int i = 0; i < LZFSE_ENCODE_LITERAL_SYMBOLS; i++) {
-    literal_occ[i].symbol = i;
-    literal_occ[i].count = 0;
-  }
+  memset(l_occ, 0, sizeof(l_occ));
+  memset(m_occ, 0, sizeof(m_occ));
+  memset(d_occ, 0, sizeof(d_occ));
+  memset(literal_occ, 0, sizeof(literal_occ));
 
   // Update occurrence tables in all 4 streams (L,M,D,literals)
   uint32_t l_sum = 0;
@@ -229,17 +217,17 @@ static int lzfse_encode_matches(lzfse_encoder_state *s) {
   for (uint32_t i = 0; i < s->n_matches; i++) {
     uint32_t l = s->l_values[i];
     l_sum += l;
-    l_occ[l_base_from_value(l)].count++;
+    l_occ[l_base_from_value(l)]++;
   }
   for (uint32_t i = 0; i < s->n_matches; i++) {
     uint32_t m = s->m_values[i];
     m_sum += m;
-    m_occ[m_base_from_value(m)].count++;
+    m_occ[m_base_from_value(m)]++;
   }
   for (uint32_t i = 0; i < s->n_matches; i++)
-    d_occ[d_base_from_value(s->d_values[i])].count++;
+    d_occ[d_base_from_value(s->d_values[i])]++;
   for (uint32_t i = 0; i < s->n_literals; i++)
-    literal_occ[s->literals[i]].count++;
+    literal_occ[s->literals[i]]++;
 
   // Make sure we have enough room for a _full_ V2 header
   if (s->dst + sizeof(lzfse_compressed_block_header_v2) > s->dst_end) {

--- a/src/lzfse_fse.h
+++ b/src/lzfse_fse.h
@@ -540,12 +540,6 @@ fse_value_decode(fse_state *__restrict pstate,
 
 #pragma mark - Tables
 
-/*! @abstract Entry in symbol occurrence table. */
-typedef struct {
-  uint32_t symbol; // Symbol identifier
-  uint32_t count;  // Number of occurrences of symbol (count >= 0)
-} fse_occurrence_entry;
-
 // IMPORTANT: To properly decode an FSE encoded stream, both encoder/decoder
 // tables shall be initialized with the same parameters, including the
 // FREQ[NSYMBOL] array.
@@ -621,12 +615,9 @@ void fse_init_value_decoder_table(int nstates, int nsymbols,
                                   const int32_t *__restrict symbol_vbase,
                                   fse_value_decoder_entry *__restrict t);
 
-/*! @abstract Normalize a table \c t[nsymbols] of symbols,occurrences to
- *  \c freq[nsymbols].
- *  @attention \c t will be modified (sorted) by this call.
- *  @return Return 1 if OK.
- *  @return 0 on failure. */
-int fse_normalize_freq(int nstates, int nsymbols, fse_occurrence_entry *t,
-                       uint16_t *freq);
+/*! @abstract Normalize a table \c t[nsymbols] of occurrences to
+ *  \c freq[nsymbols]. */
+void fse_normalize_freq(int nstates, int nsymbols, const uint32_t *__restrict t,
+                        uint16_t *__restrict freq);
 
 


### PR DESCRIPTION
The old frequency normalization algorithm did not produce good results.
This seems to have been because it was likely to round frequencies in an
unfavorable way.  Change it to an improved algorithm which produces
better results; that is, a symbol will be, on average, assigned a number
of states which better reflects its mathematical entropy.

As an added bonus, the new algorithm is faster because it requires
neither sorting the symbols nor performing floating point arithmetic.

Note that changing the way frequencies are normalized does not change the
on-disk format.

Results for compressing the Silesia corpus (211,941,764 bytes):

```
Old algorithm: Compressed to 67,809,153 bytes in 4.820 seconds
New algorithm: Compressed to 67,628,688 bytes in 4.800 seconds
```
