### PR TITLE
Fix fse_normalize_freq() when passed alphabet with no used symbols

### DIFF
--- a/src/lzfse_fse.c
+++ b/src/lzfse_fse.c
@@ -177,7 +177,10 @@ void fse_normalize_freq(int nstates, int nsymbols, const uint32_t *__restrict t,
   for (int i = 0; i < nsymbols; i++)
     s_count += t[i];
 
-  highprec_step = ((uint32_t)1 << 31) / s_count;
+  if (s_count == 0)
+    highprec_step = 0; // no symbols used
+  else
+    highprec_step = ((uint32_t)1 << 31) / s_count;
 
   for (int i = 0; i < nsymbols; i++) {
 


### PR DESCRIPTION
I discovered there was a small mistake in my new frequency normalization
code.  LZFSE can call the function with an alphabet from which no symbols
were used.  In that case, it does not matter which normalized frequencies
we choose, but we must at least avoid dividing by 0.

An example input I found that demonstrated this problem was 100,000,000
bytes of zeroes.
