### PR TITLE
Fix -Wall warnings from GCC

### DIFF
--- a/src/lzfse_fse.h
+++ b/src/lzfse_fse.h
@@ -1,7 +1,7 @@
 /*
 Copyright (c) 2015-2016, Apple Inc. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1.  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
@@ -48,7 +48,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 #  define FSE_INLINE static inline __attribute__((__always_inline__))
 #endif
 
-#pragma mark - Bit utils
+// MARK: - Bit utils
 
 /*! @abstract Signed type used to represent bit count. */
 typedef int32_t fse_bit_count;
@@ -131,7 +131,7 @@ FSE_INLINE uint32_t fse_extract_bits32(uint32_t x, fse_bit_count start,
   return fse_mask_lsb32(x >> start, nbits);
 }
 
-#pragma mark - Bit stream
+// MARK: - Bit stream
 
 // I/O streams
 // The streams can be shared between several FSE encoders/decoders, which is why
@@ -421,7 +421,7 @@ FSE_INLINE uint32_t fse_in_pull32(fse_in_stream32 *s, fse_bit_count n) {
   return result;
 }
 
-#pragma mark - Encode/Decode
+// MARK: - Encode/Decode
 
 // Map to 32/64-bit implementations and types for I/O
 #if FSE_IOSTREAM_64
@@ -548,7 +548,7 @@ fse_value_decode(fse_state *__restrict pstate,
                    fse_mask_lsb(state_and_value_bits, entry.value_bits));
 }
 
-#pragma mark - Tables
+// MARK: - Tables
 
 // IMPORTANT: To properly decode an FSE encoded stream, both encoder/decoder
 // tables shall be initialized with the same parameters, including the
@@ -629,5 +629,3 @@ void fse_init_value_decoder_table(int nstates, int nsymbols,
  *  \c freq[nsymbols]. */
 void fse_normalize_freq(int nstates, int nsymbols, const uint32_t *__restrict t,
                         uint16_t *__restrict freq);
-
-

--- a/src/lzfse_internal.h
+++ b/src/lzfse_internal.h
@@ -1,7 +1,7 @@
 /*
 Copyright (c) 2015-2016, Apple Inc. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:  
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 1.  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
 
@@ -152,7 +152,7 @@ typedef struct {
   uint32_t length;
 } lzfse_match;
 
-#pragma mark - Encoder and Decoder state objects
+// MARK: - Encoder and Decoder state objects
 
 /*! @abstract Encoder state object. */
 typedef struct {
@@ -271,7 +271,7 @@ typedef struct {
   uncompressed_block_decoder_state uncompressed_block_state;
 } lzfse_decoder_state;
 
-#pragma mark - Block header objects
+// MARK: - Block header objects
 
 #define LZFSE_NO_BLOCK_MAGIC             0x00000000 // 0    (invalid)
 #define LZFSE_ENDOFSTREAM_BLOCK_MAGIC    0x24787662 // bvx$ (end of stream)
@@ -304,7 +304,7 @@ typedef struct {
   uint32_t n_literal_payload_bytes;
   //  Number of bytes used to encode matches.
   uint32_t n_lmd_payload_bytes;
-  
+
   //  Final encoder states for the block, which will be the initial states for
   //  the decoder:
   //  Final accum_nbits for literals stream.
@@ -320,7 +320,7 @@ typedef struct {
   uint16_t m_state;
   //  Final D (match distance) state.
   uint16_t d_state;
-  
+
   //  Normalized frequency tables for each stream. Sum of values in each
   //  array is the number of states.
   uint16_t l_freq[LZFSE_ENCODE_L_SYMBOLS];
@@ -383,7 +383,7 @@ typedef struct {
   uint32_t n_payload_bytes;
 } lzvn_compressed_block_header;
 
-#pragma mark - LZFSE encode/decode interfaces
+// MARK: - LZFSE encode/decode interfaces
 
 int lzfse_encode_init(lzfse_encoder_state *s);
 int lzfse_encode_translate(lzfse_encoder_state *s, lzfse_offset delta);
@@ -391,7 +391,7 @@ int lzfse_encode_base(lzfse_encoder_state *s);
 int lzfse_encode_finish(lzfse_encoder_state *s);
 int lzfse_decode(lzfse_decoder_state *s);
 
-#pragma mark - LZVN encode/decode interfaces
+// MARK: - LZVN encode/decode interfaces
 
 //  Minimum source buffer size for compression. Smaller buffers will not be
 //  compressed; the lzvn encoder will simply return.
@@ -420,7 +420,7 @@ typedef int64_t lzvn_offset;
 typedef int32_t lzvn_offset;
 #endif
 
-#pragma mark - LZFSE utility functions
+// MARK: - LZFSE utility functions
 
 /*! @abstract Load bytes from memory location SRC. */
 LZFSE_INLINE uint16_t load2(const void *ptr) {
@@ -566,7 +566,7 @@ LZFSE_INLINE int lzfse_check_block_header_v1(
   return 0; // OK
 }
 
-#pragma mark - L, M, D encoding constants for LZFSE
+// MARK: - L, M, D encoding constants for LZFSE
 
 //  Largest encodable L (literal length), M (match length) and D (match
 //  distance) values.

--- a/src/lzfse_internal.h
+++ b/src/lzfse_internal.h
@@ -585,25 +585,25 @@ LZFSE_INLINE int lzfse_check_block_header_v1(
  * @note The inverse tables for mapping the other way are significantly larger.
  * Those tables have been split out to lzfse_encode_tables.h in order to keep
  * this file relatively small. */
-static uint8_t l_extra_bits[LZFSE_ENCODE_L_SYMBOLS] = {
+static const uint8_t l_extra_bits[LZFSE_ENCODE_L_SYMBOLS] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2, 3, 5, 8
 };
-static int32_t l_base_value[LZFSE_ENCODE_L_SYMBOLS] = {
+static const int32_t l_base_value[LZFSE_ENCODE_L_SYMBOLS] = {
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 20, 28, 60
 };
-static uint8_t m_extra_bits[LZFSE_ENCODE_M_SYMBOLS] = {
+static const uint8_t m_extra_bits[LZFSE_ENCODE_M_SYMBOLS] = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3, 5, 8, 11
 };
-static int32_t m_base_value[LZFSE_ENCODE_M_SYMBOLS] = {
+static const int32_t m_base_value[LZFSE_ENCODE_M_SYMBOLS] = {
   0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 24, 56, 312
 };
-static uint8_t d_extra_bits[LZFSE_ENCODE_D_SYMBOLS] = {
+static const uint8_t d_extra_bits[LZFSE_ENCODE_D_SYMBOLS] = {
   0,  0,  0,  0,  1,  1,  1,  1,  2,  2,  2,  2,  3,  3,  3,  3,
   4,  4,  4,  4,  5,  5,  5,  5,  6,  6,  6,  6,  7,  7,  7,  7,
   8,  8,  8,  8,  9,  9,  9,  9,  10, 10, 10, 10, 11, 11, 11, 11,
   12, 12, 12, 12, 13, 13, 13, 13, 14, 14, 14, 14, 15, 15, 15, 15
 };
-static int32_t d_base_value[LZFSE_ENCODE_D_SYMBOLS] = {
+static const int32_t d_base_value[LZFSE_ENCODE_D_SYMBOLS] = {
   0,      1,      2,      3,     4,     6,     8,     10,    12,    16,
   20,     24,     28,     36,    44,    52,    60,    76,    92,    108,
   124,    156,    188,    220,   252,   316,   380,   444,   508,   636,


### PR DESCRIPTION
-Wextra (which enables sign-compare) still produces some warnings on GCC 6, and even more on clang (due to missing-field-initializers).