### PR TITLE
Add cpack support to generate packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,11 @@ if (CMAKE_VERSION VERSION_GREATER 3.2)
   cmake_policy (SET CMP0063 NEW)
 endif ()
 
+option(BUILD_PACKAGING "Enable build of distribution packages using CPack." OFF)
+option(BUILD_PACKAGING_SOURCES "Enable build package sources using CPack." OFF)
+option(INSTALL_HEADERS "Request packaging of headers and other development files." OFF)
+mark_as_advanced(INSTALL_HEADERS)
+
 # Compiler flags
 function(lzfse_add_compiler_flags target)
   set (flags ${ARGV})
@@ -95,11 +100,20 @@ endif()
 if(NOT LZFSE_BUNDLE_MODE)
   include(GNUInstallDirs)
 
-  install(TARGETS lzfse lzfse_cli
-    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
-    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
-  install(FILES src/lzfse.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  if(BUILD_PACKAGING AND INSTALL_HEADERS)
+    install(FILES src/lzfse.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+  elseif(BUILD_PACKAGING)
+    install(TARGETS lzfse lzfse_cli
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+  else()
+    install(FILES src/lzfse.h DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    install(TARGETS lzfse lzfse_cli
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+  endif()
 endif()
 
 # Tests
@@ -134,4 +148,143 @@ if(NOT LZFSE_DISABLE_TESTS)
         -DINPUT=${CMAKE_CURRENT_SOURCE_DIR}/${INPUT}
         -P ${CMAKE_CURRENT_SOURCE_DIR}/tests/round-trip.cmake)
   endforeach()
+endif()
+
+# Packaging
+if(BUILD_PACKAGING)
+
+  if(BUILD_PACKAGING_SOURCES)
+    set(SRPM TRUE)
+  endif()
+
+  set(PACKAGE_NAME "lzfse")
+  set(PACKAGE_VERSION "1.0")
+  set(PACKAGE_STRING "${PACKAGE_NAME} ${PACKAGE_VERSION}")
+  set(PACKAGE_TARNAME "${PACKAGE_NAME}-${PACKAGE_VERSION}")
+
+  if(NOT BUILD_SHARED_LIBS AND NOT INSTALL_HEADERS)
+    message(WARNING "Package will contain static libraries without headers!"
+                    "\nRecommended options for generation of runtime package:"
+                    "\n  BUILD_SHARED_LIBS=ON"
+                    "\n  BUILD_STATIC_LIBS=OFF"
+                    "\n  INSTALL_HEADERS=OFF"
+                    "\nRecommended options for generation of development package:"
+                    "\n  BUILD_SHARED_LIBS=ON"
+                    "\n  BUILD_STATIC_LIBS=ON"
+                    "\n  INSTALL_HEADERS=ON")
+  endif()
+
+  find_program(DPKG dpkg)
+  find_program(RPM rpm)
+
+  # default package generators
+  if(APPLE)
+    set(PACKAGE_GENERATOR "PackageMaker")
+    set(PACKAGE_SOURCE_GENERATOR "TGZ;ZIP")
+  elseif(UNIX)
+    if(DPKG AND NOT RPM)
+      set(PACKAGE_GENERATOR "DEB")
+    elseif(RPM AND NOT DPKG)
+      set(PACKAGE_GENERATOR "RPM")
+    endif()
+    set(PACKAGE_SOURCE_GENERATOR "TGZ;ZIP")
+  else()
+    set(PACKAGE_GENERATOR "ZIP")
+    set(PACKAGE_SOURCE_GENERATOR "ZIP")
+  endif()
+
+  # used package generators
+  set(CPACK_GENERATOR "${PACKAGE_GENERATOR}" CACHE STRING "List of binary package generators (CPack).")
+  set(CPACK_SOURCE_GENERATOR "${PACKAGE_SOURCE_GENERATOR}" CACHE STRING "List of source package generators (CPack).")
+  mark_as_advanced(CPACK_GENERATOR CPACK_SOURCE_GENERATOR)
+
+  # common package information
+  set(CPACK_PACKAGE_VENDOR "Apple Inc.")
+  set(CPACK_PACKAGE_NAME "${PACKAGE_NAME}")
+  set(CPACK_PACKAGE_VERSION "${PACKAGE_VERSION}")
+  set(CPACK_PACKAGE_VERSION_MAJOR "${PACKAGE_VERSION_MAJOR}")
+  set(CPACK_PACKAGE_VERSION_MINOR "${PACKAGE_VERSION_MINOR}")
+  set(CPACK_PACKAGE_VERSION_PATCH "${PACKAGE_VERSION_PATCH}")
+  set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "LZFSE compression library and command line tool.")
+  set(CPACK_RESOURCE_FILE_WELCOME "${CMAKE_CURRENT_LIST_DIR}/README.md")
+  set(CPACK_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
+  set(CPACK_OUTPUT_FILE_PREFIX packages)
+  set(CPACK_PACKAGE_RELOCATABLE TRUE)
+  set(CPACK_MONOLITHIC_INSTALL TRUE)
+
+  # RPM package information -- used in cmake/package.cmake.in also for DEB
+  set(CPACK_RPM_PACKAGE_GROUP "Development/Libraries")
+  set(CPACK_RPM_PACKAGE_LICENSE "BSD")
+  set(CPACK_RPM_PACKAGE_URL "https://github.com/lzfse/lzfse")
+  set(CPACK_RPM_PACKAGE_REQUIRES "cmake, gcc")
+  set(CPACK_RPM_CHANGELOG_FILE "${CMAKE_CURRENT_LIST_DIR}/ChangeLog.txt")
+
+  # system/architecture
+  if(WINDOWS)
+    if(CMAKE_CL_64)
+      set(CPACK_SYSTEM_NAME "win64")
+    else()
+      set(CPACK_SYSTEM_NAME "win32")
+    endif()
+    set(CPACK_PACKAGE_ARCHITECTURE)
+  elseif(APPLE)
+    set(CPACK_PACKAGE_ARCHITECTURE darwin)
+  else()
+    string(TOLOWER "${CMAKE_SYSTEM_NAME}" CPACK_SYSTEM_NAME)
+    if(CMAKE_CXX_FLAGS MATCHES "-m32")
+      set(CPACK_PACKAGE_ARCHITECTURE i386)
+    else()
+      if(DPKG AND NOT RPM)
+        execute_process(
+          COMMAND dpkg --print-architecture
+          RESULT_VARIABLE RV
+          OUTPUT_VARIABLE CPACK_PACKAGE_ARCHITECTURE
+        )
+      else()
+        execute_process(
+          COMMAND rpm --eval "%{_arch}"
+          RESULT_VARIABLE RV
+          OUTPUT_VARIABLE CPACK_PACKAGE_ARCHITECTURE
+        )
+      endif()
+
+      if(RV EQUAL 0)
+	      string(STRIP "${CPACK_PACKAGE_ARCHITECTURE}" CPACK_PACKAGE_ARCHITECTURE)
+      else()
+        execute_process(COMMAND uname -m OUTPUT_VARIABLE CPACK_PACKAGE_ARCHITECTURE)
+        if(CPACK_PACKAGE_ARCHITECTURE MATCHES "x86_64")
+	        set(CPACK_PACKAGE_ARCHITECTURE amd64)
+        else()
+          set(CPACK_PACKAGE_ARCHITECTURE i386)
+        endif()
+      endif()
+    endif()
+  endif()
+
+  # source package settings
+  set(CPACK_SOURCE_TOPLEVEL_TAG "source")
+  set(CPACK_SOURCE_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}")
+  set(CPACK_SOURCE_IGNORE_FILES "/\\\\.git/;\\\\.swp$;\\\\.#;/#;\\\\.*~;cscope\\\\.*;/[Bb]uild[.+-_a-zA-Z0-9]*/")
+
+  # default binary package settings
+  set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY TRUE)
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_SYSTEM_NAME}")
+  if(CPACK_PACKAGE_ARCHITECTURE)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${CPACK_PACKAGE_ARCHITECTURE}")
+  endif()
+
+  # generator specific configuration file
+  #
+  # allow package maintainers to use their own configuration file
+  # $ cmake -DCPACK_PROJECT_CONFIG_FILE:FILE=/path/to/package/config
+  if(NOT CPACK_PROJECT_CONFIG_FILE)
+    configure_file(
+	    "${CMAKE_CURRENT_LIST_DIR}/modules/Package.cmake.in"
+      "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-package.cmake" @ONLY
+    )
+    set(CPACK_PROJECT_CONFIG_FILE "${PROJECT_BINARY_DIR}/${PACKAGE_NAME}-package.cmake")
+  endif()
+
+  include(CPack)
+
 endif()

--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,0 +1,38 @@
+* Mon May 22 2017 Apple Inc. <lzfse@apple.com> 1.0-1
+- OS X -> macOS where appropriate
+
+* Sun May 07 2017 Apple Inc. <lzfse@apple.com> 1.0
+-  fixed a typo in block max size
+-  Allow LZVN to work with inputs shorter than 8 bytes.
+-  Improved frequency normalization algorithm
+-  Do not waste time searching for length 3 matches
+-  Fix a merge conflict in the licence file
+-  Converted readme to markdown, added some further information and fixed description of two files being mixed up
+-  lzfse_fse.h: correctly detect 64-bit stream for debug macro
+-  Fix fse_normalize_freq() when passed alphabet with no used symbols
+-  reformatted LICENSE
+-  merged nemequ changes; fixed end of stream reservation size in LZVN partial encoder; fixed Xcode project with updated README.md file
+-  Added bindings section in README, link to pylzfse
+-  Add CMake build system.
+-  Added cmake instructions to README
+-  Add extern declarations for linking into C++ code.
+-  Avoid pointer arithmetic on void pointers
+-  Implement GCC bit scan builtins for MSVC
+-  Fix issues related to use of __attribute__
+-  Implement jump table as switch for non-GCC
+-  Use ptrdiff_t instead of ssize_t
+-  Add MSVC fixes for timing and file access
+-  Set _POSIX_C_SOURCE to 200112L for gettimeofday
+-  Set binary mode on stdin/stdout on Windows
+-  Update API export to work for CMake and MSVC
+-  Fix label error
+-  Fix 64-bit check for MSVC
+-  Add some tests to verify the build.
+-  Add Travis CI support.
+-  Add AppVeyor builds.
+-  Don't rely on unaligned accesses in the LZVN encoder.
+-  Get Visual Studio 12 working.
+-  Replace #pragma mark with // MARK:
+-  Add const to tables in lzfse_internal.h
+-  Fix #28
+-  Improve patch for #28

--- a/modules/Package.cmake.in
+++ b/modules/Package.cmake.in
@@ -1,0 +1,52 @@
+
+# Per-generator CPack configuration file. See CPACK_PROJECT_CONFIG_FILE documented at
+# http://www.cmake.org/cmake/help/v2.8.12/cpack.html#variable:CPACK_PROJECT_CONFIG_FILE
+#
+# All common CPACK_* variables are set in CMakeLists.txt already. This file only
+# overrides some of these to provide package generator specific settings.
+
+# whether package contains all development files or only runtime files
+set(DEVEL @INSTALL_HEADERS@)
+set(SRPM @BUILD_PACKAGING_SOURCES@)
+
+# Mac OS X package
+if(CPACK_GENERATOR MATCHES "PackageMaker|DragNDrop")
+
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}")
+  if(DEVEL)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-devel")
+  endif()
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${CPACK_PACKAGE_VERSION}")
+
+# Debian package
+elseif(CPACK_GENERATOR MATCHES "DEB")
+
+  set(CPACK_PACKAGE_FILE_NAME "lib${CPACK_PACKAGE_NAME}")
+  if(DEVEL)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-dev")
+  else()
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}0")
+  endif()
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}_${CPACK_PACKAGE_VERSION}-1_${CPACK_PACKAGE_ARCHITECTURE}")
+
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS)
+  set(CPACK_DEBIAN_PACKAGE_SECTION "devel")
+  set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
+  set(CPACK_DEBIAN_PACKAGE_HOMEPAGE "${CPACK_RPM_PACKAGE_URL}")
+  set(CPACK_DEBIAN_PACKAGE_MAINTAINER "${CPACK_PACKAGE_VENDOR}")
+  set(CPACK_DEBIAN_PACKAGE_ARCHITECTURE "${CPACK_PACKAGE_ARCHITECTURE}")
+
+# RPM package
+elseif(CPACK_GENERATOR MATCHES "RPM")
+
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}")
+  if(DEVEL)
+    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-devel")
+  endif()
+  set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${CPACK_PACKAGE_VERSION}-1.${CPACK_PACKAGE_ARCHITECTURE}")
+
+  if(SRPM)
+    set(CPACK_RPM_PACKAGE_SOURCES ON)
+  endif()
+
+endif()


### PR DESCRIPTION
This commit enables CPack for CMake to generate target packages for each platform: RPMs and DEBs.
It also generates packages for Mac and Windows platforms. The commit includes the regular packages and devel packages with the LZFSE header. To generate the package, you should pass `-DBUILD_PACKAGING=ON` and to generate devel packages you should also include `-DINSTALL_HEADERS`.

Signed-off-by: Julio Faracco <jcfaracco@gmail.com>