### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,19 @@ Building with cmake
 
 Installs the header, library, and command line tool in `/usr/local`.
 
+Building lzfse - Using vcpkg
+--------
+
+You can download and install lzfse using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install lzfse
+
+The lzfse port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Bindings
 --------
 


### PR DESCRIPTION
lzfse is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for lzfse and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build lzfse, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/lzfse/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)
